### PR TITLE
No need to depend on voc

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,7 @@
 LIBRARY=bessel
 
 $(LIBRARY).js: bessel.md
+	@[ -e node_modules/voc ] && true || npm install voc
 	node_modules/.bin/voc $^ > $@
 
 test mocha:

--- a/package.json
+++ b/package.json
@@ -11,7 +11,6 @@
 		"test": "make test"
 	},
 	"dependencies": {
-		"voc":""
 	},
 	"devDependencies": {
 		"mocha":""

--- a/test.js
+++ b/test.js
@@ -17,6 +17,6 @@ describe('When using bessel functions', function() {
     assert(Math.floor((bessel.besselk(1.5, 1) - 0.277388) * 10e6) < 10);
   });
   it('It must compute Weber\'s Bessel function at 2.5 with an order of 1 (0.145918)', function() {
-    assert(Math.floor((bessel.besselk(2.5, 1) - 0.981666) * 10e6) < 10);
+    assert(Math.floor((bessel.bessely(2.5, 1) - 0.145918) * 10e6) < 10);
   });
 });


### PR DESCRIPTION
Hi again!
Just curious: why does bessel depends on voc?
The tests are passing without it.
I could not figure out where it is used.
Thanks!